### PR TITLE
Fix getRoute GitHub Pages path handling

### DIFF
--- a/my-app-combined/test-client-routes.js
+++ b/my-app-combined/test-client-routes.js
@@ -37,15 +37,15 @@ function getRoute(path) {
   const cleanPath = path.startsWith('/') ? path.slice(1) : path;
   
   // Simular la detección del entorno
-  const isGitHubPages = typeof window !== 'undefined' && 
-    (window.location.hostname === 'benjamalegni.github.io' || 
+  const isGitHubPages = typeof window !== 'undefined' &&
+    (window.location.hostname === 'benjamalegni.github.io' ||
      window.location.pathname.startsWith('/financialfeeling'));
-  
+
   if (isGitHubPages) {
-    return `/${cleanPath}`;
+    return `/financialfeeling/${cleanPath}`;
   }
-  
-  return `/financialfeeling/${cleanPath}`;
+
+  return `/${cleanPath}`;
 }
 
 // Probar cada entorno


### PR DESCRIPTION
## Summary
- Correct `getRoute` to return `/financialfeeling/...` on GitHub Pages and `/...` otherwise

## Testing
- `npm test` (fails: Missing script: "test")
- `node my-app-combined/test-client-routes.js`


------
https://chatgpt.com/codex/tasks/task_e_68937f98582c8333931f53c6c0986018