### PR TITLE
Improve supabase client typing

### DIFF
--- a/my-app/src/app/select-assets/page.tsx
+++ b/my-app/src/app/select-assets/page.tsx
@@ -186,7 +186,7 @@ export default function SelectAssetsPage() {
             </div>
           )}
           {searchTerm && searchResults.length === 0 && (
-            <p className="text-n8n-text-secondary text-sm text-center">No assets found for "{searchTerm}".</p>
+            <p className="text-n8n-text-secondary text-sm text-center">No assets found for &quot;{searchTerm}&quot;.</p>
           )}
 
           {selectedAssets.size > 0 && (

--- a/my-app/src/lib/supabaseClient.ts
+++ b/my-app/src/lib/supabaseClient.ts
@@ -1,13 +1,14 @@
 import { createClient } from '@supabase/supabase-js'
+import type { Database } from './database.types'
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
 if (!supabaseUrl) {
-  throw new Error("Missing env.NEXT_PUBLIC_SUPABASE_URL")
+  throw new Error('Missing env.NEXT_PUBLIC_SUPABASE_URL')
 }
 if (!supabaseAnonKey) {
-  throw new Error("Missing env.NEXT_PUBLIC_SUPABASE_ANON_KEY")
+  throw new Error('Missing env.NEXT_PUBLIC_SUPABASE_ANON_KEY')
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey)


### PR DESCRIPTION
## Summary
- type Supabase client with Database schema
- escape quotes in select-assets message to satisfy ESLint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68937e3029448333911d1627bbf13b36