### PR TITLE
Implement carousel typography for financial analysis section

### DIFF
--- a/my-app-combined/app/globals.css
+++ b/my-app-combined/app/globals.css
@@ -3,6 +3,37 @@
 
 @custom-variant dark (&:is(.dark *));
 
+@font-face {
+  font-family: 'SeasonSerif';
+  src: url('/fonts/SeasonSerif-Regular.woff2') format('woff2'),
+       url('/fonts/SeasonSerif-Regular.woff') format('woff');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'SeasonSerif';
+  src: url('/fonts/SeasonSerif-Medium.woff2') format('woff2'),
+       url('/fonts/SeasonSerif-Medium.woff') format('woff');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'SeasonSerif';
+  src: url('/fonts/SeasonSerif-Bold.woff2') format('woff2'),
+       url('/fonts/SeasonSerif-Bold.woff') format('woff');
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+.font-season {
+  font-family: 'SeasonSerif', serif;
+}
+
 :root {
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);

--- a/my-app-combined/app/page.tsx
+++ b/my-app-combined/app/page.tsx
@@ -805,7 +805,7 @@ export default function HomePage() {
 
               {/* How to Use Section */}
               <div className="mb-8">
-                <h2 className="text-6xl font-bold mb-6 text-center">Learn to Use Stock Analysis</h2>
+                <h2 className="text-6xl font-season font-bold mb-6 text-center">Learn to Use Financial Analysis</h2>
 
                 <Card className="bg-gray-900 border-gray-700">
                   <CardContent className="p-8">

--- a/my-app-combined/components/3d-carousel.tsx
+++ b/my-app-combined/components/3d-carousel.tsx
@@ -46,10 +46,10 @@ export default function Carousel3D({ steps, interval = 4000 }: Carousel3DProps) 
               }}
             >
               <div className="text-center max-w-md">
-                <div className="text-6xl font-bold mb-4" style={{ color: step.color }}>
+                <div className="text-6xl font-season font-bold mb-4" style={{ color: step.color }}>
                   {i + 1}
                 </div>
-                <h3 className="text-2xl font-bold text-white mb-4">{step.title}</h3>
+                <h3 className="text-2xl font-season font-bold text-white mb-4">{step.title}</h3>
                 <p className="text-gray-300 text-lg">{step.description}</p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add SeasonSerif font-face and utility class
- update landing page heading to "Learn to Use Financial Analysis"
- apply new font to 3D carousel steps

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893b1d766ec83338d2679fcfb01e4a4